### PR TITLE
Update build.gradle to use config from root project.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,18 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 27)
+    //noinspection GradleDependency
+    buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        //noinspection OldTargetApi
+        targetSdkVersion safeExtGet('targetSdkVersion', 27)
         targetSdkVersion 21
         versionCode 7
         versionName "0.0.1"
@@ -13,6 +20,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.17.+'
+    implementation 'com.facebook.react:react-native:+'
 }
 

--- a/android/src/main/java/com/darryncampbell/rndatawedgeintents/RNDataWedgeIntentsPackage.java
+++ b/android/src/main/java/com/darryncampbell/rndatawedgeintents/RNDataWedgeIntentsPackage.java
@@ -20,11 +20,6 @@ public class RNDataWedgeIntentsPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/darryncampbell/rndatawedgeintents/RNDataWedgeIntentsPackage.java
+++ b/android/src/main/java/com/darryncampbell/rndatawedgeintents/RNDataWedgeIntentsPackage.java
@@ -18,6 +18,10 @@ public class RNDataWedgeIntentsPackage implements ReactPackage {
         modules.add(new RNDataWedgeIntentsModule(reactContext));
         return modules;
     }
+    
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {


### PR DESCRIPTION
Updated build.gradle to utilise the information from root project, instead of manually adding them. It also adds a fall back if there are no variables defined in the root project.