### PR TITLE
fixing leak genericReceiver when react-native devtools reload

### DIFF
--- a/android/src/main/java/com/darryncampbell/rndatawedgeintents/RNDataWedgeIntentsModule.java
+++ b/android/src/main/java/com/darryncampbell/rndatawedgeintents/RNDataWedgeIntentsModule.java
@@ -125,6 +125,14 @@ public class RNDataWedgeIntentsModule extends ReactContextBaseJavaModule impleme
       }
       try
       {
+          this.reactContext.unregisterReceiver(genericReceiver);
+      }
+      catch (IllegalArgumentException e)
+      {
+          //  Expected behaviour if there was not a previously registered receiver.
+      }
+      try
+      {
           this.reactContext.unregisterReceiver(scannedDataBroadcastReceiver);
       }
       catch (IllegalArgumentException e)


### PR DESCRIPTION
this issued produced when we reload react-native, it duplicated

first time 
![image](https://user-images.githubusercontent.com/5879298/70233342-f7e60d80-1790-11ea-873d-1b43d11132f5.png)
 
reload
![image](https://user-images.githubusercontent.com/5879298/70233448-2663e880-1791-11ea-9021-b65844ef9899.png)

2nd reload
![image](https://user-images.githubusercontent.com/5879298/70233498-4398b700-1791-11ea-8da4-fa3ee955aff7.png)
