### PR TITLE
Support for broadcasts other than Zebra/Symbol

### DIFF
--- a/android/src/main/java/com/darryncampbell/rndatawedgeintents/RNDataWedgeIntentsModule.java
+++ b/android/src/main/java/com/darryncampbell/rndatawedgeintents/RNDataWedgeIntentsModule.java
@@ -457,10 +457,11 @@ public class RNDataWedgeIntentsModule extends ReactContextBaseJavaModule impleme
       if (intent.hasExtra("v2API"))
       {
           Bundle intentBundle = intent.getExtras();
-          
-          // Remove byte arrays (fb converter cannot cope with byte arrays)
-          for (String key : intentBundle.keySet()) {
-              if (intentBundle.get(key) instanceof byte[]) {
+
+          // Remove arrays (fb converter cannot cope with byte arrays)
+          for (String key : new ArrayList<String>(intentBundle.keySet())) {
+              Object extraValue = intentBundle.get(key);
+              if (extraValue instanceof byte[] || extraValue instanceof ArrayList || extraValue instanceof ArrayList<?>) {
                   intentBundle.remove(key);
               }
           }

--- a/android/src/main/java/com/darryncampbell/rndatawedgeintents/RNDataWedgeIntentsModule.java
+++ b/android/src/main/java/com/darryncampbell/rndatawedgeintents/RNDataWedgeIntentsModule.java
@@ -457,8 +457,14 @@ public class RNDataWedgeIntentsModule extends ReactContextBaseJavaModule impleme
       if (intent.hasExtra("v2API"))
       {
           Bundle intentBundle = intent.getExtras();
-          intentBundle.remove("com.symbol.datawedge.decode_data"); //  fb converter cannot cope with byte arrays
-          intentBundle.remove("com.motorolasolutions.emdk.datawedge.decode_data"); //  fb converter cannot cope with byte arrays
+          
+          // Remove byte arrays (fb converter cannot cope with byte arrays)
+          for (String key : intentBundle.keySet()) {
+              if (intentBundle.get(key) instanceof byte[]) {
+                  intentBundle.remove(key);
+              }
+          }
+          
           WritableMap map = Arguments.fromBundle(intentBundle);
           sendEvent(this.reactContext, "datawedge_broadcast_intent", map);
       }


### PR DESCRIPTION
I've created a fix to be able to use other broadcasts as well (using the SendBroadcastWithExtras API).

Before, two (fixed) extra values were removed as they contain byte arrays:
- com.symbol.datawedge.decode_data
- com.motorolasolutions.emdk.datawedge.decode_data

If there are any other byte arrays, it results in a crash.
Now any extra value containing a byte arrays is removed. This makes it possible to use this library with other systems as well. I've tested it with the Honeywell Intent API which is working fine. Zebra/Symbol is still working the same way as before.