### PR TITLE
Prevent iOS devices from crashing when using module in single app for both platforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,14 @@
  * @providesModule DataWedgeIntents
  */
 
-'use strict';
+"use strict";
 
-var { Platform, NativeModules } = require('react-native');
-var RNDataWedgeIntents = NativeModules.DataWedgeIntents;
+var { Platform, NativeModules } = require("react-native");
 
-var DataWedgeIntents = {
+if (Platform.OS === "android") {
+  var RNDataWedgeIntents = NativeModules.DataWedgeIntents;
+
+  var DataWedgeIntents = {
     //  Specifying the DataWedge API constants in this module is deprecated.  It is not feasible to stay current with the DW API.
     ACTION_SOFTSCANTRIGGER: RNDataWedgeIntents.ACTION_SOFTSCANTRIGGER,
     ACTION_SCANNERINPUTPLUGIN: RNDataWedgeIntents.ACTION_SCANNERINPUTPLUGIN,
@@ -22,19 +24,20 @@ var DataWedgeIntents = {
     DISABLE_PLUGIN: RNDataWedgeIntents.DISABLE_PLUGIN,
 
     sendIntent(action, parameterValue) {
-        //  THIS METHOD IS DEPRECATED, use SendBroadcastWithExtras
-        RNDataWedgeIntents.sendIntent(action, parameterValue);
+      //  THIS METHOD IS DEPRECATED, use SendBroadcastWithExtras
+      RNDataWedgeIntents.sendIntent(action, parameterValue);
     },
     sendBroadcastWithExtras(extrasObject) {
-        RNDataWedgeIntents.sendBroadcastWithExtras(extrasObject);
+      RNDataWedgeIntents.sendBroadcastWithExtras(extrasObject);
     },
     registerBroadcastReceiver(filter) {
-        RNDataWedgeIntents.registerBroadcastReceiver(filter);
+      RNDataWedgeIntents.registerBroadcastReceiver(filter);
     },
     registerReceiver(action, category) {
-        //  THIS METHOD IS DEPRECATED, use registerBroadcastReceiver
-        RNDataWedgeIntents.registerReceiver(action, category);
+      //  THIS METHOD IS DEPRECATED, use registerBroadcastReceiver
+      RNDataWedgeIntents.registerReceiver(action, category);
     },
-};
+  };
 
-module.exports = DataWedgeIntents;
+  module.exports = DataWedgeIntents;
+}

--- a/index.js
+++ b/index.js
@@ -2,40 +2,19 @@
  * @providesModule DataWedgeIntents
  */
 
-"use strict";
+'use strict';
 
-var { Platform, NativeModules } = require("react-native");
+var { Platform, NativeModules } = require('react-native');
 
-if (Platform.OS === "android") {
+if (Platform.OS === 'android') {
   var RNDataWedgeIntents = NativeModules.DataWedgeIntents;
 
   var DataWedgeIntents = {
-    //  Specifying the DataWedge API constants in this module is deprecated.  It is not feasible to stay current with the DW API.
-    ACTION_SOFTSCANTRIGGER: RNDataWedgeIntents.ACTION_SOFTSCANTRIGGER,
-    ACTION_SCANNERINPUTPLUGIN: RNDataWedgeIntents.ACTION_SCANNERINPUTPLUGIN,
-    ACTION_ENUMERATESCANNERS: RNDataWedgeIntents.ACTION_ENUMERATESCANNERS,
-    ACTION_SETDEFAULTPROFILE: RNDataWedgeIntents.ACTION_SETDEFAULTPROFILE,
-    ACTION_RESETDEFAULTPROFILE: RNDataWedgeIntents.ACTION_RESETDEFAULTPROFILE,
-    ACTION_SWITCHTOPROFILE: RNDataWedgeIntents.ACTION_SWITCHTOPROFILE,
-    START_SCANNING: RNDataWedgeIntents.START_SCANNING,
-    STOP_SCANNING: RNDataWedgeIntents.STOP_SCANNING,
-    TOGGLE_SCANNING: RNDataWedgeIntents.TOGGLE_SCANNING,
-    ENABLE_PLUGIN: RNDataWedgeIntents.ENABLE_PLUGIN,
-    DISABLE_PLUGIN: RNDataWedgeIntents.DISABLE_PLUGIN,
-
-    sendIntent(action, parameterValue) {
-      //  THIS METHOD IS DEPRECATED, use SendBroadcastWithExtras
-      RNDataWedgeIntents.sendIntent(action, parameterValue);
-    },
     sendBroadcastWithExtras(extrasObject) {
       RNDataWedgeIntents.sendBroadcastWithExtras(extrasObject);
     },
     registerBroadcastReceiver(filter) {
       RNDataWedgeIntents.registerBroadcastReceiver(filter);
-    },
-    registerReceiver(action, category) {
-      //  THIS METHOD IS DEPRECATED, use registerBroadcastReceiver
-      RNDataWedgeIntents.registerReceiver(action, category);
     },
   };
 


### PR DESCRIPTION
Closes #21

Hello, as discussed I have added this simple check for Android and checked on a couple of devices that are not Zebra ( Huawei and Samsung ), and looks like it works without any problems. Not sure if this is the best solution, but works for our project atm.

The reason that I have this problem is we are building an RN app for scanning that also uses a camera and runs on both platforms so outside of Zebra devices ( at least for our project ) I do not need to have intents.

I have also removed all those deprecated values since they are not in types and maybe they can be removed in the latest version and kept in previous ones.

One more thing, our app uses functional components so I adapted intents to be used with 2 simple hooks. One hook runs on startup, checks if the profile is set, if so, it does not reset it again or sets it if there is specified profile from config. Another hook is used when we need access to scanned values or a list of all scans on the current screen.

I would be happy to share that code for example app if you are interested or help any other way I can.